### PR TITLE
Truth matching

### DIFF
--- a/FlatTuple/AnalyzeKinFitDelphes.C
+++ b/FlatTuple/AnalyzeKinFitDelphes.C
@@ -373,12 +373,12 @@ void AnalyzeKinFitDelphes::Loop(const string modeStr, const string outFileName)
     }
     // Do the deltaR matching to the reconstructed objects
     b_genMatch = 0; // [lep][nu][lepB][hadJ1][hadJ2][hadB]
-    if ( gen_lep.Pt()   > 0 and gen_lep.DeltaR(leptonP4)    < 0.1 ) b_genMatch |= 1<<5;
-    if ( gen_nu.Pt()    > 0 and gen_nu.DeltaPhi(metP4)      < 0.1 ) b_genMatch |= 1<<4;
-    if ( gen_lepB.Pt()  > 0 and gen_lepB.DeltaR(jetP4s[0])  < 0.1 ) b_genMatch |= 1<<3;
-    if ( gen_hadJ1.Pt() > 0 and gen_hadJ1.DeltaR(jetP4s[1]) < 0.1 ) b_genMatch |= 1<<2;
-    if ( gen_hadJ2.Pt() > 0 and gen_hadJ2.DeltaR(jetP4s[2]) < 0.1 ) b_genMatch |= 1<<1;
-    if ( gen_hadB.Pt()  > 0 and gen_hadB.DeltaR(jetP4s[3])  < 0.1 ) b_genMatch |= 1<<0;
+    if ( gen_lep.Pt()   > 0 and gen_lep.DeltaR(sol_lepP4)    < 0.1 ) b_genMatch |= 1<<5;
+    if ( gen_nu.Pt()    > 0 and gen_nu.DeltaR(sol_nuP4)      < 0.1 ) b_genMatch |= 1<<4;
+    if ( gen_lepB.Pt()  > 0 and gen_lepB.DeltaR(sol_ljP4)  < 0.1 ) b_genMatch |= 1<<3;
+    if ( gen_hadJ1.Pt() > 0 and (gen_hadJ1.DeltaR(sol_wj1P4) < 0.1 or gen_hadJ1.DeltaR(sol_wj2P4) < 0.1) ) b_genMatch |= 1<<2;
+    if ( gen_hadJ2.Pt() > 0 and (gen_hadJ2.DeltaR(sol_wj1P4) < 0.1 or gen_hadJ2.DeltaR(sol_wj2P4) < 0.1) ) b_genMatch |= 1<<1;
+    if ( gen_hadB.Pt()  > 0 and gen_hadB.DeltaR(sol_hbP4)  < 0.1 ) b_genMatch |= 1<<0;
 
     hLW_m->Fill( (sol_lepP4+sol_nuP4).M() );
     hLT_m->Fill( (sol_lepP4+sol_nuP4+sol_ljP4).M() );

--- a/FlatTuple/AnalyzeKinFitDelphes.C
+++ b/FlatTuple/AnalyzeKinFitDelphes.C
@@ -345,11 +345,11 @@ void AnalyzeKinFitDelphes::Loop(const string modeStr, const string outFileName)
       if ( mother < 0 or abs(gen_pdgId[mother]) != 6 ) continue; // Should be from top quark decay
 
       const int sibling1 = gen_dau1[mother], sibling2 = gen_dau2[mother];
-      if ( sibling2-sibling1 != 2 or sibling2 < 0 or sibling1 < 0 ) continue; // two siblingings (including itself), t->Wb or t->Hc
+      if ( sibling2-sibling1 != 1 or sibling2 < 0 or sibling1 < 0 ) continue; // two siblingings (including itself), t->Wb or t->Hc
       const int sibling = (sibling1 == int(i)) ? sibling2 : sibling1;
 
       int dau1 = gen_dau1[i], dau2 = gen_dau2[i];
-      if ( dau2-dau1 != 2 or dau1 < 0 or dau2 < 0 ) continue; // should have two daughters only
+      if ( dau2-dau1 != 1 or dau1 < 0 or dau2 < 0 ) continue; // should have two daughters only
       if ( abs(dau1) > abs(dau2) ) swap(dau1, dau2);
 
       if ( abs(gen_pdgId[dau1]) <= 5 and abs(gen_pdgId[dau2]) <= 5 ) { // W->jj or H->bb

--- a/FlatTuple/AnalyzeKinFitDelphes.C
+++ b/FlatTuple/AnalyzeKinFitDelphes.C
@@ -336,10 +336,49 @@ void AnalyzeKinFitDelphes::Loop(const string modeStr, const string outFileName)
     const auto& sol_wj1P4 = solution[3], sol_wj2P4 = solution[4], sol_hbP4 = solution[5];
 
     // Generator level objects
-    b_genMatch = 0; // [lep][nu][lepB][hadJ1][hadJ2][hadB][addJ1][addJ2]
     TLorentzVector gen_lep, gen_nu, gen_lepB, gen_hadJ1, gen_hadJ2, gen_hadB;
-    for ( size_t i=0; i<b_gen_n; ++i ) {
+    for ( size_t i=0; i<gen_n; ++i ) {
+      const int absId = abs(gen_pdgId[i]);
+      if ( absId != 24 and absId != 25 ) continue;
+
+      const int mother = gen_mother[i];
+      if ( mother < 0 or abs(gen_pdgId[mother]) != 6 ) continue; // Should be from top quark decay
+
+      const int sibling1 = gen_dau1[mother], sibling2 = gen_dau2[mother];
+      if ( sibling2-sibling1 != 2 or sibling2 < 0 or sibling1 < 0 ) continue; // two siblingings (including itself), t->Wb or t->Hc
+      const int sibling = (sibling1 == int(i)) ? sibling2 : sibling1;
+
+      int dau1 = gen_dau1[i], dau2 = gen_dau2[i];
+      if ( dau2-dau1 != 2 or dau1 < 0 or dau2 < 0 ) continue; // should have two daughters only
+      if ( abs(dau1) > abs(dau2) ) swap(dau1, dau2);
+
+      if ( abs(gen_pdgId[dau1]) <= 5 and abs(gen_pdgId[dau2]) <= 5 ) { // W->jj or H->bb
+        gen_hadJ1.SetPtEtaPhiM(gen_pt[dau1], gen_eta[dau1], gen_phi[dau1], gen_m[dau1]);
+        gen_hadJ2.SetPtEtaPhiM(gen_pt[dau2], gen_eta[dau2], gen_phi[dau2], gen_m[dau2]);
+        gen_hadB.SetPtEtaPhiM(gen_pt[sibling], gen_eta[sibling], gen_phi[sibling], gen_m[sibling]);
+      }
+      else {
+        if ( abs(gen_pdgId[dau1]) == 15 ) {
+          for ( int j=gen_dau1[dau1]; j<=gen_dau2[dau1]; ++j ) {
+            if ( j < 0 ) continue;
+            const int aid = abs(gen_pdgId[j]);
+            if ( aid == 11 or aid == 13 ) { dau1 = j; break; }
+          }
+        }
+
+        gen_lep.SetPtEtaPhiM(gen_pt[dau1], gen_eta[dau1], gen_phi[dau1], gen_m[dau1]);
+        gen_nu.SetPtEtaPhiM(gen_pt[dau2], gen_eta[dau2], gen_phi[dau2], gen_m[dau2]);
+        gen_lepB.SetPtEtaPhiM(gen_pt[sibling], gen_eta[sibling], gen_phi[sibling], gen_m[sibling]);
+      }
     }
+    // Do the deltaR matching to the reconstructed objects
+    b_genMatch = 0; // [lep][nu][lepB][hadJ1][hadJ2][hadB]
+    if ( gen_lep.Pt()   > 0 and gen_lep.DeltaR(leptonP4)    < 0.1 ) b_genMatch |= 1<<5;
+    if ( gen_nu.Pt()    > 0 and gen_nu.DeltaPhi(metP4)      < 0.1 ) b_genMatch |= 1<<4;
+    if ( gen_lepB.Pt()  > 0 and gen_lepB.DeltaR(jetP4s[0])  < 0.1 ) b_genMatch |= 1<<3;
+    if ( gen_hadJ1.Pt() > 0 and gen_hadJ1.DeltaR(jetP4s[1]) < 0.1 ) b_genMatch |= 1<<2;
+    if ( gen_hadJ2.Pt() > 0 and gen_hadJ2.DeltaR(jetP4s[2]) < 0.1 ) b_genMatch |= 1<<1;
+    if ( gen_hadB.Pt()  > 0 and gen_hadB.DeltaR(jetP4s[3])  < 0.1 ) b_genMatch |= 1<<0;
 
     hLW_m->Fill( (sol_lepP4+sol_nuP4).M() );
     hLT_m->Fill( (sol_lepP4+sol_nuP4+sol_ljP4).M() );

--- a/FlatTuple/AnalyzeKinFitDelphes.h
+++ b/FlatTuple/AnalyzeKinFitDelphes.h
@@ -55,6 +55,7 @@ public :
    Float_t         gen_m[100];   //[gen_n]
    Short_t         gen_pdgId[100];   //[gen_n]
    Short_t         gen_q3[100];   //[gen_n]
+   Short_t         gen_mother[100];   //[gen_n]
    Short_t         gen_dau1[100];   //[gen_n]
    Short_t         gen_dau2[100];   //[gen_n]
    UShort_t        subjets_n;
@@ -98,6 +99,7 @@ public :
    TBranch        *b_gen_m;   //!
    TBranch        *b_gen_pdgId;   //!
    TBranch        *b_gen_q3;   //!
+   TBranch        *b_gen_mother;   //!
    TBranch        *b_gen_dau1;   //!
    TBranch        *b_gen_dau2;   //!
    TBranch        *b_subjets_n;
@@ -225,6 +227,7 @@ void AnalyzeKinFitDelphes::Init(TTree *tree)
    fChain->SetBranchAddress("gen_m", gen_m, &b_gen_m);
    fChain->SetBranchAddress("gen_pdgId", gen_pdgId, &b_gen_pdgId);
    fChain->SetBranchAddress("gen_q3", gen_q3, &b_gen_q3);
+   fChain->SetBranchAddress("gen_mother", gen_mother, &b_gen_mother);
    fChain->SetBranchAddress("gen_dau1", gen_dau1, &b_gen_dau1);
    fChain->SetBranchAddress("gen_dau2", gen_dau2, &b_gen_dau2);
    fChain->SetBranchAddress("subjets_n", &subjets_n, &b_subjets_n);

--- a/FlatTuple/AnalyzeM3Delphes.C
+++ b/FlatTuple/AnalyzeM3Delphes.C
@@ -373,11 +373,11 @@ void AnalyzeM3Delphes::Loop(const string modeStr, const string outFileName, stri
       if ( mother < 0 or abs(gen_pdgId[mother]) != 6 ) continue; // Should be from top quark decay
 
       const int sibling1 = gen_dau1[mother], sibling2 = gen_dau2[mother];
-      if ( sibling2-sibling1 != 2 or sibling2 < 0 or sibling1 < 0 ) continue; // two siblingings (including itself), t->Wb or t->Hc
+      if ( sibling2-sibling1 != 1 or sibling2 < 0 or sibling1 < 0 ) continue; // two siblingings (including itself), t->Wb or t->Hc
       const int sibling = (sibling1 == int(i)) ? sibling2 : sibling1;
 
       int dau1 = gen_dau1[i], dau2 = gen_dau2[i];
-      if ( dau2-dau1 != 2 or dau1 < 0 or dau2 < 0 ) continue; // should have two daughters only
+      if ( dau2-dau1 != 1 or dau1 < 0 or dau2 < 0 ) continue; // should have two daughters only
       if ( abs(dau1) > abs(dau2) ) swap(dau1, dau2);
 
       if ( abs(gen_pdgId[dau1]) <= 5 and abs(gen_pdgId[dau2]) <= 5 ) { // W->jj or H->bb

--- a/FlatTuple/AnalyzeM3Delphes.C
+++ b/FlatTuple/AnalyzeM3Delphes.C
@@ -364,10 +364,49 @@ void AnalyzeM3Delphes::Loop(const string modeStr, const string outFileName, stri
     }
 
     // Generator level objects
-    b_genMatch = 0; // [lep][nu][lepB][hadJ1][hadJ2][hadB][addJ1][addJ2]
     TLorentzVector gen_lep, gen_nu, gen_lepB, gen_hadJ1, gen_hadJ2, gen_hadB;
-    for ( size_t i=0; i<b_gen_n; ++i ) {
+    for ( size_t i=0; i<gen_n; ++i ) {
+      const int absId = abs(gen_pdgId[i]);
+      if ( absId != 24 and absId != 25 ) continue;
+
+      const int mother = gen_mother[i];
+      if ( mother < 0 or abs(gen_pdgId[mother]) != 6 ) continue; // Should be from top quark decay
+
+      const int sibling1 = gen_dau1[mother], sibling2 = gen_dau2[mother];
+      if ( sibling2-sibling1 != 2 or sibling2 < 0 or sibling1 < 0 ) continue; // two siblingings (including itself), t->Wb or t->Hc
+      const int sibling = (sibling1 == int(i)) ? sibling2 : sibling1;
+
+      int dau1 = gen_dau1[i], dau2 = gen_dau2[i];
+      if ( dau2-dau1 != 2 or dau1 < 0 or dau2 < 0 ) continue; // should have two daughters only
+      if ( abs(dau1) > abs(dau2) ) swap(dau1, dau2);
+
+      if ( abs(gen_pdgId[dau1]) <= 5 and abs(gen_pdgId[dau2]) <= 5 ) { // W->jj or H->bb
+        gen_hadJ1.SetPtEtaPhiM(gen_pt[dau1], gen_eta[dau1], gen_phi[dau1], gen_m[dau1]);
+        gen_hadJ2.SetPtEtaPhiM(gen_pt[dau2], gen_eta[dau2], gen_phi[dau2], gen_m[dau2]);
+        gen_hadB.SetPtEtaPhiM(gen_pt[sibling], gen_eta[sibling], gen_phi[sibling], gen_m[sibling]);
+      }
+      else {
+        if ( abs(gen_pdgId[dau1]) == 15 ) {
+          for ( int j=gen_dau1[dau1]; j<=gen_dau2[dau1]; ++j ) {
+            if ( j < 0 ) continue;
+            const int aid = abs(gen_pdgId[j]);
+            if ( aid == 11 or aid == 13 ) { dau1 = j; break; }
+          }
+        }
+
+        gen_lep.SetPtEtaPhiM(gen_pt[dau1], gen_eta[dau1], gen_phi[dau1], gen_m[dau1]);
+        gen_nu.SetPtEtaPhiM(gen_pt[dau2], gen_eta[dau2], gen_phi[dau2], gen_m[dau2]);
+        gen_lepB.SetPtEtaPhiM(gen_pt[sibling], gen_eta[sibling], gen_phi[sibling], gen_m[sibling]);
+      }
     }
+    // Do the deltaR matching to the reconstructed objects
+    b_genMatch = 0; // [lep][nu][lepB][hadJ1][hadJ2][hadB]
+    if ( gen_lep.Pt()   > 0 and gen_lep.DeltaR(leptonP4)    < 0.1 ) b_genMatch |= 1<<5;
+    if ( gen_nu.Pt()    > 0 and gen_nu.DeltaPhi(metP4)      < 0.1 ) b_genMatch |= 1<<4;
+    if ( gen_lepB.Pt()  > 0 and gen_lepB.DeltaR(jetP4s[0])  < 0.1 ) b_genMatch |= 1<<3;
+    if ( gen_hadJ1.Pt() > 0 and gen_hadJ1.DeltaR(jetP4s[1]) < 0.1 ) b_genMatch |= 1<<2;
+    if ( gen_hadJ2.Pt() > 0 and gen_hadJ2.DeltaR(jetP4s[2]) < 0.1 ) b_genMatch |= 1<<1;
+    if ( gen_hadB.Pt()  > 0 and gen_hadB.DeltaR(jetP4s[3])  < 0.1 ) b_genMatch |= 1<<0;
 
     hLW_m->Fill( (leptonP4+metP4).M() );
     hLT_m->Fill( (leptonP4+metP4+jetP4s[0]).M() );

--- a/FlatTuple/AnalyzeM3Delphes.C
+++ b/FlatTuple/AnalyzeM3Delphes.C
@@ -404,8 +404,8 @@ void AnalyzeM3Delphes::Loop(const string modeStr, const string outFileName, stri
     if ( gen_lep.Pt()   > 0 and gen_lep.DeltaR(leptonP4)    < 0.1 ) b_genMatch |= 1<<5;
     if ( gen_nu.Pt()    > 0 and gen_nu.DeltaPhi(metP4)      < 0.1 ) b_genMatch |= 1<<4;
     if ( gen_lepB.Pt()  > 0 and gen_lepB.DeltaR(jetP4s[0])  < 0.1 ) b_genMatch |= 1<<3;
-    if ( gen_hadJ1.Pt() > 0 and gen_hadJ1.DeltaR(jetP4s[1]) < 0.1 ) b_genMatch |= 1<<2;
-    if ( gen_hadJ2.Pt() > 0 and gen_hadJ2.DeltaR(jetP4s[2]) < 0.1 ) b_genMatch |= 1<<1;
+    if ( gen_hadJ1.Pt() > 0 and (gen_hadJ1.DeltaR(jetP4s[1]) < 0.1 or gen_hadJ1.DeltaR(jetP4s[2]) < 0.1) ) b_genMatch |= 1<<2;
+    if ( gen_hadJ2.Pt() > 0 and (gen_hadJ2.DeltaR(jetP4s[1]) < 0.1 or gen_hadJ2.DeltaR(jetP4s[2]) < 0.1) ) b_genMatch |= 1<<1;
     if ( gen_hadB.Pt()  > 0 and gen_hadB.DeltaR(jetP4s[3])  < 0.1 ) b_genMatch |= 1<<0;
 
     hLW_m->Fill( (leptonP4+metP4).M() );

--- a/FlatTuple/AnalyzeM3Delphes.h
+++ b/FlatTuple/AnalyzeM3Delphes.h
@@ -55,6 +55,7 @@ public :
    Float_t         gen_m[100];   //[gen_n]
    Short_t         gen_pdgId[100];   //[gen_n]
    Short_t         gen_q3[100];   //[gen_n]
+   Short_t         gen_mother[100];   //[gen_n]
    Short_t         gen_dau1[100];   //[gen_n]
    Short_t         gen_dau2[100];   //[gen_n]
    UShort_t        subjets_n;
@@ -98,6 +99,7 @@ public :
    TBranch        *b_gen_m;   //!
    TBranch        *b_gen_pdgId;   //!
    TBranch        *b_gen_q3;   //!
+   TBranch        *b_gen_mother;   //!
    TBranch        *b_gen_dau1;   //!
    TBranch        *b_gen_dau2;   //!
    TBranch        *b_subjets_n;
@@ -225,6 +227,7 @@ void AnalyzeM3Delphes::Init(TTree *tree)
    fChain->SetBranchAddress("gen_m", gen_m, &b_gen_m);
    fChain->SetBranchAddress("gen_pdgId", gen_pdgId, &b_gen_pdgId);
    fChain->SetBranchAddress("gen_q3", gen_q3, &b_gen_q3);
+   fChain->SetBranchAddress("gen_mother", gen_mother, &b_gen_mother);
    fChain->SetBranchAddress("gen_dau1", gen_dau1, &b_gen_dau1);
    fChain->SetBranchAddress("gen_dau2", gen_dau2, &b_gen_dau2);
    fChain->SetBranchAddress("subjets_n", &subjets_n, &b_subjets_n);

--- a/FlatTuple/run_KinFit.C
+++ b/FlatTuple/run_KinFit.C
@@ -4,7 +4,7 @@ R__LOAD_LIBRARY(TTLJKinFit.C+)
 R__LOAD_LIBRARY(AnalyzeKinFitHYTuple.C+)
 R__LOAD_LIBRARY(AnalyzeKinFitDelphes.C+)
 
-const string mode = "FCNC";
+const string mode = "FCNC"; // mode set to FCNC, require 3 b jets
 //const string mode = "tt";
 
 void run_CMSKinFit();
@@ -30,8 +30,8 @@ void run_CMSKinFit()
   AnalyzeKinFitHYTuple tFCNC(&chainFCNC);
   AnalyzeKinFitHYTuple tTTBB(&chainTTBB);
 
-  tFCNC.Loop(mode, "kin/cmsTuple_FCNC.root"); // mode set to FCNC, require 3 b jets
-  tTTBB.Loop(mode, "kin/cmsTuple_ttbb.root"); // mode set to FCNC, require 3 b jets
+  tFCNC.Loop(mode, "kin/cmsTuple_FCNC.root");
+  tTTBB.Loop(mode, "kin/cmsTuple_ttbb.root");
 }
 
 void run_DelphesKinFit()
@@ -40,11 +40,16 @@ void run_DelphesKinFit()
   chainFCNC.Add("../Delphes2Flat/ntuple_tch.root");
 
   TChain chainTTBB("tree");
-  chainTTBB.Add("../Delphes2Flat/ntuple_tt.root");
+  chainTTBB.Add("../Delphes2Flat/ntuple_ttbb.root");
+
+  TChain chainTTJJ("tree");
+  chainTTJJ.Add("../Delphes2Flat/ntuple_tt.root");
 
   AnalyzeKinFitDelphes tFCNC(&chainFCNC);
   AnalyzeKinFitDelphes tTTBB(&chainTTBB);
+  AnalyzeKinFitDelphes tTTJJ(&chainTTJJ);
 
-  tFCNC.Loop(mode, "kin/delphes_FCNC.root"); // mode set to FCNC, require 3 b jets
-  tTTBB.Loop(mode, "kin/delphes_tt.root"); // mode set to FCNC, require 3 b jets
+  tFCNC.Loop(mode, "kin/delphes_FCNC.root");
+  tTTBB.Loop(mode, "kin/delphes_ttbb.root");
+  tTTJJ.Loop(mode, "kin/delphes_tt.root");
 }

--- a/FlatTuple/run_M3.C
+++ b/FlatTuple/run_M3.C
@@ -43,9 +43,14 @@ void run_DelphesM3()
   TChain chainTTBB("tree");
   chainTTBB.Add("../Delphes2Flat/ntuple_ttbb.root");
 
+  TChain chainTTJJ("tree");
+  chainTTJJ.Add("../Delphes2Flat/ntuple_ttbb.root");
+
   AnalyzeM3Delphes tFCNC(&chainFCNC);
   AnalyzeM3Delphes tTTBB(&chainTTBB);
+  AnalyzeM3Delphes tTTJJ(&chainTTJJ);
 
   tFCNC.Loop(mode, Form("%s/delphes_FCNC.root", algo), algo);
   tTTBB.Loop(mode, Form("%s/delphes_ttbb.root", algo), algo);
+  tTTJJ.Loop(mode, Form("%s/delphes_tt.root", algo), algo);
 }


### PR DESCRIPTION
Truth matching을 구현.

기존 #2 에서 추가된 gen_mother, gen_dau1, gen_dau2 정보를 이용해 top quark붕괴 과정을 generator level에서 찾아 final state 입자들의 four momentum을 찾아낸다. 그 다음 M3, mininum-deltaR 또는 kin reco에서 재구성한 four momentum과 DeltaR (M3/minDR 에서는 deltaPhi)가 0.1이하가 되면 matching이 된 것으로 간주한다.

matching정보는 [lep][nu][lepB][hadJ1][hadJ2][hadB] 순서로 비트셋으로 저장한다.

```
    b_genMatch = 0; // [lep][nu][lepB][hadJ1][hadJ2][hadB]
    if ( gen_lep.Pt()   > 0 and gen_lep.DeltaR(leptonP4)    < 0.1 ) b_genMatch |= 1<<5;
    if ( gen_nu.Pt()    > 0 and gen_nu.DeltaPhi(metP4)      < 0.1 ) b_genMatch |= 1<<4;
    if ( gen_lepB.Pt()  > 0 and gen_lepB.DeltaR(jetP4s[0])  < 0.1 ) b_genMatch |= 1<<3;
    if ( gen_hadJ1.Pt() > 0 and gen_hadJ1.DeltaR(jetP4s[1]) < 0.1 ) b_genMatch |= 1<<2;
    if ( gen_hadJ2.Pt() > 0 and gen_hadJ2.DeltaR(jetP4s[2]) < 0.1 ) b_genMatch |= 1<<1;
    if ( gen_hadB.Pt()  > 0 and gen_hadB.DeltaR(jetP4s[3])  < 0.1 ) b_genMatch |= 1<<0;
```

전부 매칭된 것을 요구하려면,
```
bool isMatched = (b_genMatch == ((1<<6)-1));
```
또는 
```
bool isMatched = (b_genMatch == 63);
```
을 사용하면 된다. 

논리 연산자 & 를 이용해 세부 조건을 조정할 수 있다.